### PR TITLE
Changed the default for max_iter to 10 , max_items  to empty , max_k …

### DIFF
--- a/methods/expression_toolkit_estimate_k/spec.json
+++ b/methods/expression_toolkit_estimate_k/spec.json
@@ -44,10 +44,10 @@
     }
   }, {
     "id" : "max_k",
-    "optional" : true,
-    "advanced" : true,
+    "optional" : false,
+    "advanced" : false,
     "allow_multiple" : false,
-    "default_values" : [ "100" ],
+    "default_values" : [ "200" ],
     "field_type" : "text",
     "text_options" : {
       "valid_ws_types" : [ ],
@@ -56,10 +56,10 @@
     }
   }, {
     "id" : "max_iter",
-    "optional" : true,
-    "advanced" : true,
+    "optional" : false,
+    "advanced" : false,
     "allow_multiple" : false,
-    "default_values" : [ "10" ],
+    "default_values" : [ "100" ],
     "field_type" : "text",
     "text_options" : {
       "valid_ws_types" : [ ],

--- a/methods/expression_toolkit_estimate_k/spec.json
+++ b/methods/expression_toolkit_estimate_k/spec.json
@@ -47,7 +47,7 @@
     "optional" : true,
     "advanced" : true,
     "allow_multiple" : false,
-    "default_values" : [ "200" ],
+    "default_values" : [ "100" ],
     "field_type" : "text",
     "text_options" : {
       "valid_ws_types" : [ ],
@@ -59,7 +59,7 @@
     "optional" : true,
     "advanced" : true,
     "allow_multiple" : false,
-    "default_values" : [ "100" ],
+    "default_values" : [ "10" ],
     "field_type" : "text",
     "text_options" : {
       "valid_ws_types" : [ ],
@@ -84,7 +84,7 @@
     "optional" : true,
     "advanced" : true,
     "allow_multiple" : false,
-    "default_values" : [ "15000" ],
+    "default_values" : [ "" ],
     "field_type" : "text",
     "text_options" : {
       "valid_ws_types" : [ ],

--- a/methods/expression_toolkit_estimate_k_new/display.yaml
+++ b/methods/expression_toolkit_estimate_k_new/display.yaml
@@ -1,0 +1,80 @@
+#
+# Define basic display information
+#
+name     : Estimate K for Expression Data ( New ) 
+
+tooltip  : |
+    Calculate an optimal value of k for use in k-means clustering method
+screenshots :
+    []
+
+#
+# Define the set of other narrative methods that should be suggested to the user.
+#
+method-suggestions :
+    related :
+        []
+    next :
+        []
+
+
+#
+# Configure the display and description of the parameters
+#
+parameters :
+    input_expression_matrix:
+        ui-name : |
+            Expression Matrix
+        short-hint : |
+            Expression Matrix to use for estimating value of k 
+        long-hint  : |
+            Expression Matrix to use for estimating value of k 
+    output_estimated_k :
+        ui-name : |
+            Estimated number of clusters
+        short-hint : |
+            Provide name for estimated number of clusters output
+        long-hint  : |
+            Provide name for estimated number of clusters output
+    min_k :
+        ui-name : Min. Number of Clusters
+        short-hint : Minimum number of clusters
+        long-hint  : Minimum number of clusters
+
+    max_k :
+        ui-name : Max. Number of Clusters
+        short-hint : Maximum number of clusters
+        long-hint  : Maximum number of clusters
+
+    criterion :
+        ui-name : Criterion
+        short-hint : Criterion for calculating average Silhouette width
+        long-hint  : Criterion for calculating average Silhouette width
+
+    usepam:
+        ui-name : Usepam
+        short-hint : If TRUE, pam is used , otherwise clara (recommended for large datasets >2000 observations)
+        long-hint  : If TRUE, pam is used , otherwise clara (recommended for large datasets >2000 observations)
+
+    alpha:
+        ui-name : alpha
+        short-hint : Numeric between 0 and 1
+        long-hint  : Numeric between 0 and 1
+
+    diss:
+        ui-name : diss
+        short-hint : Set it TRUE for dissimilarity matrix
+        long-hint  : Set it TRUE for dissimilarity matrix
+  
+    random_seed :
+        ui-name : Random Seed
+        short-hint : Random seed used by K-means algorithm
+        long-hint  : Random seed used by K-means algorithm
+
+
+description : |
+    <p>This method computes an optimal number of clusters (k) for use in the K-Means Clustering for Expression Data method. This is achieved by minimizing both the number of clusters (k) and the average variance between the clusters. Begin by selecting or importing an expression dataset to analyze using the Add Data button. Provide a name for the output estimate and run the method to calculate an optimal value for k.</p>
+    
+    <p><strong>Team members who developed & deployed algorithm in KBase:</strong>
+    Paramvir Dehal, Roman Sutormin, Michael Sneddon, Srividya Ramakrishnan, Pavel Novichkov, Keith Keller.</p>
+    <p>For questions, <a href="mailto:help@kbase.us">e-mail help@kbase.us</a></p>

--- a/methods/expression_toolkit_estimate_k_new/spec.json
+++ b/methods/expression_toolkit_estimate_k_new/spec.json
@@ -1,0 +1,149 @@
+{
+  "name" : "Estimate K for Expression Data ( New )",
+  "ver" : "1.0.0",
+  "authors" : [ ],
+  "contact" : "help@kbase.us",
+  "visble" : true,
+  "categories" : ["active"],
+  "widgets" : {
+    "input" : null,
+    "output" : "kbaseExpressionToolkitEstimateKResult"
+  },
+  "parameters" : [ {
+    "id" : "input_expression_matrix",
+    "optional" : false,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ "KBaseFeatureValues.ExpressionMatrix" ]
+    }
+  }, {
+    "id" : "output_estimated_k",
+    "optional" : false,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ "KBaseFeatureValues.EstimateKResult" ],
+      "is_output_name":true
+    }
+  }, {
+    "id" : "min_k",
+    "optional" : true,
+    "advanced" : true,
+    "allow_multiple" : false,
+    "default_values" : [ "2" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ ],
+      "validate_as": "int",
+      "min_int" : 2
+    }
+  }, {
+    "id" : "max_k",
+    "optional" : false,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "200" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ ],
+      "validate_as": "int",
+      "min_int" : 2
+    }
+  }, {
+    "id" : "criterion",
+    "optional" : false,
+    "advanced" : false,
+    "allow_multiple" : false,
+    "default_values" : [ "asw" ],
+    "field_type" : "dropdown",
+    "dropdown_options":{
+      "options": [
+        {
+          "value": "asw",
+          "display": "asw",
+          "id": "asw",
+          "ui_name": "asw"
+        },
+        {
+          "value": "multiasw",
+          "display": "multiasw",
+          "id": "multiasw",
+          "ui_name": "multiasw"
+        },
+        {
+          "value": "ch",
+          "display": "ch",
+          "id": "ch",
+          "ui_name": "ch"
+        }
+      ]
+    }
+  }, {
+    "id" : "usepam",
+    "optional" : true,
+    "advanced" : true,
+    "allow_multiple" : false,
+    "default_values" : [ "10" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ ],
+      "validate_as": "bool",
+    }
+  }, {
+    "id" : "alpha",
+    "optional" : true,
+    "advanced" : true,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ ],
+      "validate_as": "float",
+    }
+  }, {
+    "id" : "diss",
+    "optional" : true,
+    "advanced" : true,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ ],
+      "validate_as": "bool",
+    }
+  },{
+    "id" : "random_seed",
+    "optional" : true,
+    "advanced" : true,
+    "allow_multiple" : false,
+    "default_values" : [ "" ],
+    "field_type" : "text",
+    "text_options" : {
+      "valid_ws_types" : [ ],
+      "validate_as": "int"
+    }
+  } ],
+  "behavior" : {
+    "none" : {
+      "output_mapping" : [
+        {
+          "input_parameter": "input_expression_matrix",
+          "target_property": "expressionMatrix"
+        },
+        {
+          "input_parameter": "output_estimated_k",
+          "target_property": "estimateKResultId"
+        },
+        {
+          "narrative_system_variable": "workspace",
+          "target_property": "workspaceID"
+        },
+      ]
+    }
+  }
+}

--- a/methods/expression_toolkit_estimate_k_new/spec.json
+++ b/methods/expression_toolkit_estimate_k_new/spec.json
@@ -88,9 +88,18 @@
     "optional" : true,
     "advanced" : true,
     "allow_multiple" : false,
-    "default_values" : [ "FALSE" ],
-    "field_type" : "text",
-    "text_options" : {
+    "default_values" : [ "" ],
+    "field_type" : "dropdown",
+    "dropdown_options":{
+      "options": [
+        {
+          "value": "TRUE",
+          "display": "TRUE"
+        },
+        {
+          "value": "FALSE",
+          "display": "FALSE"
+        }
     }
   }, {
     "id" : "alpha",
@@ -108,9 +117,18 @@
     "optional" : true,
     "advanced" : true,
     "allow_multiple" : false,
-    "default_values" : [ "FALSE" ],
-    "field_type" : "text",
-    "text_options" : {
+    "default_values" : [ "" ],
+    "field_type" : "dropdown",
+    "dropdown_options":{
+      "options": [
+        {
+          "value": "TRUE",
+          "display": "TRUE"
+        },
+        {
+          "value": "FALSE",
+          "display": "FALSE"
+        }
     }
   },{
     "id" : "random_seed",
@@ -138,7 +156,7 @@
         {
           "narrative_system_variable": "workspace",
           "target_property": "workspaceID"
-        },
+        }
       ]
     }
   }

--- a/methods/expression_toolkit_estimate_k_new/spec.json
+++ b/methods/expression_toolkit_estimate_k_new/spec.json
@@ -88,11 +88,10 @@
     "optional" : true,
     "advanced" : true,
     "allow_multiple" : false,
-    "default_values" : [ "10" ],
+    "default_values" : [ "FALSE" ],
     "field_type" : "text",
     "text_options" : {
-      "valid_ws_types" : [ ],
-      "validate_as": "bool",
+      "valid_ws_types" : [ ]
     }
   }, {
     "id" : "alpha",
@@ -103,18 +102,17 @@
     "field_type" : "text",
     "text_options" : {
       "valid_ws_types" : [ ],
-      "validate_as": "float",
+      "validate_as": "float"
     }
   }, {
     "id" : "diss",
     "optional" : true,
     "advanced" : true,
     "allow_multiple" : false,
-    "default_values" : [ "" ],
+    "default_values" : [ "FALSE" ],
     "field_type" : "text",
     "text_options" : {
-      "valid_ws_types" : [ ],
-      "validate_as": "bool",
+      "valid_ws_types" : [ ]
     }
   },{
     "id" : "random_seed",

--- a/methods/expression_toolkit_estimate_k_new/spec.json
+++ b/methods/expression_toolkit_estimate_k_new/spec.json
@@ -91,7 +91,6 @@
     "default_values" : [ "FALSE" ],
     "field_type" : "text",
     "text_options" : {
-      "valid_ws_types" : [ ]
     }
   }, {
     "id" : "alpha",
@@ -112,7 +111,6 @@
     "default_values" : [ "FALSE" ],
     "field_type" : "text",
     "text_options" : {
-      "valid_ws_types" : [ ]
     }
   },{
     "id" : "random_seed",

--- a/methods/expression_toolkit_estimate_k_new/spec.json
+++ b/methods/expression_toolkit_estimate_k_new/spec.json
@@ -100,6 +100,7 @@
           "value": "FALSE",
           "display": "FALSE"
         }
+      ]
     }
   }, {
     "id" : "alpha",
@@ -129,6 +130,7 @@
           "value": "FALSE",
           "display": "FALSE"
         }
+      ]
     }
   },{
     "id" : "random_seed",


### PR DESCRIPTION
…to 100 as defaults

When running estimate_k on a smaller dataset with the defaults before , I was getting this error  Quick-TRANSfer stage steps exceeded maximum (= 31834400), However lowering these bounds, I could run it successfully. Set max_k to 100 as most datasets converge before a 100 clusters. Also as the cluster size increases running time exponentially.