### PR TITLE
reverted max_items from being required

### DIFF
--- a/methods/expression_toolkit_estimate_k/spec.json
+++ b/methods/expression_toolkit_estimate_k/spec.json
@@ -81,8 +81,8 @@
     }
   }, {
     "id" : "max_items",
-    "optional" : false,
-    "advanced" : false,
+    "optional" : true,
+    "advanced" : true,
     "allow_multiple" : false,
     "default_values" : [ "" ],
     "field_type" : "text",


### PR DESCRIPTION
max_items ,  not needed for smaller datasets. I will add a description to the fields in display.yaml