### PR TITLE
New categories added to match categories.yml (including 'Upload')

### DIFF
--- a/categories/annotation/spec.json
+++ b/categories/annotation/spec.json
@@ -1,0 +1,7 @@
+{
+  "name" : "Genome Annotation",
+  "parent" : [ ],
+  "tooltip" : "",
+  "ver" : "1.0.0",
+  "visible" : true
+}

--- a/categories/assembly/spec.json
+++ b/categories/assembly/spec.json
@@ -1,0 +1,7 @@
+{
+  "name" : "Genome Assembly",
+  "parent" : [ ],
+  "tooltip" : "",
+  "ver" : "1.0.0",
+  "visible" : true
+}

--- a/categories/communities/spec.json
+++ b/categories/communities/spec.json
@@ -1,0 +1,7 @@
+{
+  "name" : "Microbial Communities",
+  "parent" : [ ],
+  "tooltip" : "",
+  "ver" : "1.0.0",
+  "visible" : true
+}

--- a/categories/comparative_genomics/spec.json
+++ b/categories/comparative_genomics/spec.json
@@ -1,0 +1,7 @@
+{
+  "name" : "Comparative Genomics",
+  "parent" : [ ],
+  "tooltip" : "",
+  "ver" : "1.0.0",
+  "visible" : true
+}

--- a/categories/expression/spec.json
+++ b/categories/expression/spec.json
@@ -1,0 +1,7 @@
+{
+  "name" : "Expression",
+  "parent" : [ ],
+  "tooltip" : "",
+  "ver" : "1.0.0",
+  "visible" : true
+}

--- a/categories/metabolic_modeling/spec.json
+++ b/categories/metabolic_modeling/spec.json
@@ -1,0 +1,7 @@
+{
+  "name" : "Metabolic Modeling",
+  "parent" : [ ],
+  "tooltip" : "",
+  "ver" : "1.0.0",
+  "visible" : true
+}

--- a/categories/reads/spec.json
+++ b/categories/reads/spec.json
@@ -1,0 +1,7 @@
+{
+  "name" : "Read Processing",
+  "parent" : [ ],
+  "tooltip" : "",
+  "ver" : "1.0.0",
+  "visible" : true
+}

--- a/categories/sequence/spec.json
+++ b/categories/sequence/spec.json
@@ -1,0 +1,7 @@
+{
+  "name" : "Sequence Analysis",
+  "parent" : [ ],
+  "tooltip" : "",
+  "ver" : "1.0.0",
+  "visible" : true
+}

--- a/categories/upload/spec.json
+++ b/categories/upload/spec.json
@@ -1,0 +1,7 @@
+{
+  "name" : "Upload Methods",
+  "parent" : [ ],
+  "tooltip" : "",
+  "ver" : "1.0.0",
+  "visible" : true
+}

--- a/categories/util/spec.json
+++ b/categories/util/spec.json
@@ -1,0 +1,7 @@
+{
+  "name" : "Utilities",
+  "parent" : [ ],
+  "tooltip" : "",
+  "ver" : "1.0.0",
+  "visible" : true
+}


### PR DESCRIPTION
Upload, which is used for some apps, is not included in categories.yml file. 
Added Upload also. 

"new categories added to match https://github.com/kbase/kbase-ui-plugin-catalog/blob/master/src/plugin/modules/data/categories.yml

With this change, NarrativeMethodStore.get_category method can get names of all of the categories from their ids. E.g. id: 'annotation' name: 'Genome Annotation'."